### PR TITLE
Fix EncodeListItemValue to support arrays object

### DIFF
--- a/src/ToonFormat/Internal/Encode/Encoders.cs
+++ b/src/ToonFormat/Internal/Encode/Encoders.cs
@@ -428,18 +428,31 @@ namespace ToonFormat.Internal.Encode
             {
                 writer.PushListItem(depth, Primitives.EncodePrimitive(value, options.Delimiter));
             }
-            else if (Normalize.IsJsonArray(value) && Normalize.IsArrayOfPrimitives((JsonArray)value!))
+            else if (Normalize.IsJsonArray(value))
             {
                 var arr = (JsonArray)value!;
-                var inline = EncodeInlineArrayLine(arr, options.Delimiter, null, options.LengthMarker);
-                writer.PushListItem(depth, inline);
+                
+                // Primitive arrays use inline format
+                if (Normalize.IsArrayOfPrimitives(arr))
+                {
+                    var inline = EncodeInlineArrayLine(arr, options.Delimiter, null, options.LengthMarker);
+                    writer.PushListItem(depth, inline);
+                }
+                else
+                {
+                    var header = Primitives.FormatHeader(arr.Count, null, null, options.Delimiter, options.LengthMarker);
+                    writer.PushListItem(depth, header);
+                    foreach (var item in arr)
+                    {
+                        EncodeListItemValue(item, writer, depth + 1, options);
+                    }
+                }
             }
             else if (Normalize.IsJsonObject(value))
             {
                 EncodeObjectAsListItem((JsonObject)value!, writer, depth, options);
             }
         }
-
         // #endregion
     }
 }


### PR DESCRIPTION
## Description

EncodeListItemValue support now an array of objects instead of only supporting primites arrays 
## Type of Change

<!-- Mark the relevant option with an [x] -->

- [ X] Bug fix (non-breaking change that fixes an issue

## Related Issues

https://github.com/toon-format/toon-dotnet/issues/7