### PR TITLE
feat: add async APIs for ToonEncoder and ToonDecoder

### DIFF
--- a/src/ToonFormat/ToonDecoder.cs
+++ b/src/ToonFormat/ToonDecoder.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
 using ToonFormat;
 using ToonFormat.Internal.Decode;
 
@@ -194,4 +196,124 @@ public static class ToonDecoder
         var text = reader.ReadToEnd();
         return Decode<T>(text, options ?? new ToonDecodeOptions());
     }
+
+    #region Async Methods
+
+    /// <summary>
+    /// Asynchronously decodes a TOON-formatted string into a JsonNode with default options.
+    /// </summary>
+    /// <param name="toonString">The TOON-formatted string to decode.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the decoded JsonNode.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when toonString is null.</exception>
+    /// <exception cref="ToonFormatException">Thrown when the TOON format is invalid.</exception>
+    public static Task<JsonNode?> DecodeAsync(string toonString, CancellationToken cancellationToken = default)
+    {
+        return DecodeAsync(toonString, new ToonDecodeOptions(), cancellationToken);
+    }
+
+    /// <summary>
+    /// Asynchronously decodes a TOON-formatted string into a JsonNode with custom options.
+    /// </summary>
+    /// <param name="toonString">The TOON-formatted string to decode.</param>
+    /// <param name="options">Decoding options to customize parsing behavior.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the decoded JsonNode.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when toonString or options is null.</exception>
+    /// <exception cref="ToonFormatException">Thrown when the TOON format is invalid.</exception>
+    public static Task<JsonNode?> DecodeAsync(string toonString, ToonDecodeOptions? options, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var result = Decode(toonString, options);
+        return Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Asynchronously decodes a TOON-formatted string into the specified type with default options.
+    /// </summary>
+    /// <typeparam name="T">Target type to deserialize into.</typeparam>
+    /// <param name="toonString">The TOON-formatted string to decode.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the deserialized value.</returns>
+    public static Task<T?> DecodeAsync<T>(string toonString, CancellationToken cancellationToken = default)
+    {
+        return DecodeAsync<T>(toonString, new ToonDecodeOptions(), cancellationToken);
+    }
+
+    /// <summary>
+    /// Asynchronously decodes a TOON-formatted string into the specified type with custom options.
+    /// </summary>
+    /// <typeparam name="T">Target type to deserialize into.</typeparam>
+    /// <param name="toonString">The TOON-formatted string to decode.</param>
+    /// <param name="options">Decoding options to customize parsing behavior.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the deserialized value.</returns>
+    public static Task<T?> DecodeAsync<T>(string toonString, ToonDecodeOptions? options, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var result = Decode<T>(toonString, options);
+        return Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Asynchronously decodes TOON data from a stream (UTF-8) into a JsonNode with default options.
+    /// </summary>
+    /// <param name="stream">The input stream to read from.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the decoded JsonNode.</returns>
+    public static Task<JsonNode?> DecodeAsync(Stream stream, CancellationToken cancellationToken = default)
+    {
+        return DecodeAsync(stream, new ToonDecodeOptions(), cancellationToken);
+    }
+
+    /// <summary>
+    /// Asynchronously decodes TOON data from a stream (UTF-8) into a JsonNode with custom options.
+    /// </summary>
+    /// <param name="stream">The input stream to read from.</param>
+    /// <param name="options">Decoding options to customize parsing behavior.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the decoded JsonNode.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when stream is null.</exception>
+    public static async Task<JsonNode?> DecodeAsync(Stream stream, ToonDecodeOptions? options, CancellationToken cancellationToken = default)
+    {
+        if (stream == null)
+            throw new ArgumentNullException(nameof(stream));
+
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: true);
+        var text = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+        return Decode(text, options ?? new ToonDecodeOptions());
+    }
+
+    /// <summary>
+    /// Asynchronously decodes TOON data from a stream (UTF-8) into the specified type with default options.
+    /// </summary>
+    /// <typeparam name="T">Target type to deserialize into.</typeparam>
+    /// <param name="stream">The input stream to read from.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the deserialized value.</returns>
+    public static Task<T?> DecodeAsync<T>(Stream stream, CancellationToken cancellationToken = default)
+    {
+        return DecodeAsync<T>(stream, new ToonDecodeOptions(), cancellationToken);
+    }
+
+    /// <summary>
+    /// Asynchronously decodes TOON data from a stream (UTF-8) into the specified type with custom options.
+    /// </summary>
+    /// <typeparam name="T">Target type to deserialize into.</typeparam>
+    /// <param name="stream">The input stream to read from.</param>
+    /// <param name="options">Decoding options to customize parsing behavior.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the deserialized value.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when stream is null.</exception>
+    public static async Task<T?> DecodeAsync<T>(Stream stream, ToonDecodeOptions? options, CancellationToken cancellationToken = default)
+    {
+        if (stream == null)
+            throw new ArgumentNullException(nameof(stream));
+
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: true);
+        var text = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+        return Decode<T>(text, options ?? new ToonDecodeOptions());
+    }
+
+    #endregion
 }

--- a/src/ToonFormat/ToonEncoder.cs
+++ b/src/ToonFormat/ToonEncoder.cs
@@ -3,6 +3,8 @@ using System;
 using System.ComponentModel;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using ToonFormat;
 using ToonFormat.Internal.Encode;
 
@@ -192,4 +194,97 @@ public static class ToonEncoder
         var bytes = EncodeToBytes(data, options);
         destination.Write(bytes, 0, bytes.Length);
     }
+
+    #region Async Methods
+
+    /// <summary>
+    /// Asynchronously encodes the specified value into TOON format with default options.
+    /// </summary>
+    /// <typeparam name="T">Type of the value to encode.</typeparam>
+    /// <param name="data">The value to encode.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the TOON-formatted string.</returns>
+    public static Task<string> EncodeAsync<T>(T data, CancellationToken cancellationToken = default)
+    {
+        return EncodeAsync(data, new ToonEncodeOptions(), cancellationToken);
+    }
+
+    /// <summary>
+    /// Asynchronously encodes the specified value into TOON format with custom options.
+    /// </summary>
+    /// <typeparam name="T">Type of the value to encode.</typeparam>
+    /// <param name="data">The value to encode.</param>
+    /// <param name="options">Encoding options to customize the output format.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the TOON-formatted string.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when options is null.</exception>
+    public static Task<string> EncodeAsync<T>(T data, ToonEncodeOptions? options, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var result = Encode(data, options);
+        return Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Asynchronously encodes the specified value into UTF-8 bytes with default options.
+    /// </summary>
+    /// <typeparam name="T">Type of the value to encode.</typeparam>
+    /// <param name="data">The value to encode.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the UTF-8 encoded TOON bytes.</returns>
+    public static Task<byte[]> EncodeToBytesAsync<T>(T data, CancellationToken cancellationToken = default)
+    {
+        return EncodeToBytesAsync(data, new ToonEncodeOptions(), cancellationToken);
+    }
+
+    /// <summary>
+    /// Asynchronously encodes the specified value into UTF-8 bytes with custom options.
+    /// </summary>
+    /// <typeparam name="T">Type of the value to encode.</typeparam>
+    /// <param name="data">The value to encode.</param>
+    /// <param name="options">Encoding options to customize the output format.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the UTF-8 encoded TOON bytes.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when options is null.</exception>
+    public static Task<byte[]> EncodeToBytesAsync<T>(T data, ToonEncodeOptions? options, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var result = EncodeToBytes(data, options);
+        return Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Asynchronously encodes the specified value and writes UTF-8 bytes to the destination stream using default options.
+    /// </summary>
+    /// <typeparam name="T">Type of the value to encode.</typeparam>
+    /// <param name="data">The value to encode.</param>
+    /// <param name="destination">The destination stream to write to. The stream is not disposed.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous write operation.</returns>
+    public static Task EncodeToStreamAsync<T>(T data, Stream destination, CancellationToken cancellationToken = default)
+    {
+        return EncodeToStreamAsync(data, destination, new ToonEncodeOptions(), cancellationToken);
+    }
+
+    /// <summary>
+    /// Asynchronously encodes the specified value and writes UTF-8 bytes to the destination stream using custom options.
+    /// </summary>
+    /// <typeparam name="T">Type of the value to encode.</typeparam>
+    /// <param name="data">The value to encode.</param>
+    /// <param name="destination">The destination stream to write to. The stream is not disposed.</param>
+    /// <param name="options">Encoding options to customize the output format.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous write operation.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when destination or options is null.</exception>
+    public static async Task EncodeToStreamAsync<T>(T data, Stream destination, ToonEncodeOptions? options, CancellationToken cancellationToken = default)
+    {
+        if (destination == null)
+            throw new ArgumentNullException(nameof(destination));
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var bytes = EncodeToBytes(data, options);
+        await destination.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
+    }
+
+    #endregion
 }

--- a/tests/ToonFormat.Tests/ToonAsyncTests.cs
+++ b/tests/ToonFormat.Tests/ToonAsyncTests.cs
@@ -1,0 +1,262 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using Toon.Format;
+using Xunit;
+
+namespace ToonFormat.Tests;
+
+/// <summary>
+/// Tests for async encoding and decoding methods.
+/// </summary>
+public class ToonAsyncTests
+{
+    #region EncodeAsync Tests
+
+    [Fact]
+    public async Task EncodeAsync_WithSimpleObject_ReturnsValidToon()
+    {
+        // Arrange
+        var data = new { name = "Alice", age = 30 };
+
+        // Act
+        var result = await ToonEncoder.EncodeAsync(data);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Contains("name:", result);
+        Assert.Contains("Alice", result);
+        Assert.Contains("age:", result);
+        Assert.Contains("30", result);
+    }
+
+    [Fact]
+    public async Task EncodeAsync_WithOptions_RespectsIndentation()
+    {
+        // Arrange
+        var data = new { outer = new { inner = "value" } };
+        var options = new ToonEncodeOptions { Indent = 4 };
+
+        // Act
+        var result = await ToonEncoder.EncodeAsync(data, options);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Contains("outer:", result);
+    }
+
+    [Fact]
+    public async Task EncodeAsync_WithCancellationToken_ThrowsWhenCancelled()
+    {
+        // Arrange
+        var data = new { name = "Test" };
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => ToonEncoder.EncodeAsync(data, cts.Token));
+    }
+
+    [Fact]
+    public async Task EncodeToBytesAsync_WithSimpleObject_ReturnsUtf8Bytes()
+    {
+        // Arrange
+        var data = new { message = "Hello" };
+
+        // Act
+        var result = await ToonEncoder.EncodeToBytesAsync(data);
+
+        // Assert
+        Assert.NotNull(result);
+        var text = Encoding.UTF8.GetString(result);
+        Assert.Contains("message:", text);
+        Assert.Contains("Hello", text);
+    }
+
+    [Fact]
+    public async Task EncodeToStreamAsync_WritesToStream()
+    {
+        // Arrange
+        var data = new { id = 123 };
+        using var stream = new MemoryStream();
+
+        // Act
+        await ToonEncoder.EncodeToStreamAsync(data, stream);
+
+        // Assert
+        stream.Position = 0;
+        using var reader = new StreamReader(stream);
+        var result = await reader.ReadToEndAsync();
+        Assert.Contains("id:", result);
+        Assert.Contains("123", result);
+    }
+
+    [Fact]
+    public async Task EncodeToStreamAsync_WithNullStream_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var data = new { name = "Test" };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => ToonEncoder.EncodeToStreamAsync(data, null!));
+    }
+
+    #endregion
+
+    #region DecodeAsync Tests
+
+    [Fact]
+    public async Task DecodeAsync_WithValidToon_ReturnsJsonNode()
+    {
+        // Arrange
+        var toon = "name: Alice\nage: 30";
+
+        // Act
+        var result = await ToonDecoder.DecodeAsync(toon);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<JsonObject>(result);
+        var obj = (JsonObject)result;
+        Assert.Equal("Alice", obj["name"]?.GetValue<string>());
+        Assert.Equal(30.0, obj["age"]?.GetValue<double>());
+    }
+
+    [Fact]
+    public async Task DecodeAsync_Generic_DeserializesToType()
+    {
+        // Arrange
+        var toon = "name: Bob\nage: 25";
+
+        // Act
+        var result = await ToonDecoder.DecodeAsync<TestPerson>(toon);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Bob", result.name);
+        Assert.Equal(25, result.age);
+    }
+
+    [Fact]
+    public async Task DecodeAsync_WithCancellationToken_ThrowsWhenCancelled()
+    {
+        // Arrange
+        var toon = "name: Test";
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => ToonDecoder.DecodeAsync(toon, cts.Token));
+    }
+
+    [Fact]
+    public async Task DecodeAsync_FromStream_ReturnsJsonNode()
+    {
+        // Arrange
+        var toon = "message: Hello World";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(toon));
+
+        // Act
+        var result = await ToonDecoder.DecodeAsync(stream);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<JsonObject>(result);
+        var obj = (JsonObject)result;
+        Assert.Equal("Hello World", obj["message"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task DecodeAsync_Generic_FromStream_DeserializesToType()
+    {
+        // Arrange
+        var toon = "name: Charlie\nage: 35";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(toon));
+
+        // Act
+        var result = await ToonDecoder.DecodeAsync<TestPerson>(stream);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Charlie", result.name);
+        Assert.Equal(35, result.age);
+    }
+
+    [Fact]
+    public async Task DecodeAsync_FromStream_WithNullStream_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => ToonDecoder.DecodeAsync((Stream)null!));
+    }
+
+    [Fact]
+    public async Task DecodeAsync_WithOptions_RespectsStrictMode()
+    {
+        // Arrange - array declares 5 items but only provides 3, strict mode should throw
+        var toon = "numbers[5]: 1, 2, 3";
+        var options = new ToonDecodeOptions { Strict = true };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ToonFormatException>(
+            () => ToonDecoder.DecodeAsync(toon, options));
+    }
+
+    #endregion
+
+    #region Round-Trip Async Tests
+
+    [Fact]
+    public async Task AsyncRoundTrip_PreservesData()
+    {
+        // Arrange
+        var original = new TestPerson { name = "Diana", age = 28 };
+
+        // Act
+        var encoded = await ToonEncoder.EncodeAsync(original);
+        var decoded = await ToonDecoder.DecodeAsync<TestPerson>(encoded);
+
+        // Assert
+        Assert.NotNull(decoded);
+        Assert.Equal(original.name, decoded.name);
+        Assert.Equal(original.age, decoded.age);
+    }
+
+    [Fact]
+    public async Task AsyncStreamRoundTrip_PreservesData()
+    {
+        // Arrange
+        var original = new TestPerson { name = "Eve", age = 32 };
+        using var stream = new MemoryStream();
+
+        // Act
+        await ToonEncoder.EncodeToStreamAsync(original, stream);
+        stream.Position = 0;
+        var decoded = await ToonDecoder.DecodeAsync<TestPerson>(stream);
+
+        // Assert
+        Assert.NotNull(decoded);
+        Assert.Equal(original.name, decoded.name);
+        Assert.Equal(original.age, decoded.age);
+    }
+
+    #endregion
+
+    #region Test Helpers
+
+    private class TestPerson
+    {
+        public string? name { get; set; }
+        public int age { get; set; }
+    }
+
+    #endregion
+}
+


### PR DESCRIPTION
## Summary

Adds asynchronous API support to the TOON library, enabling non-blocking encoding and decoding operations.

## Changes

### ToonEncoder
- `EncodeAsync<T>()` - Async encoding with default/custom options
- `EncodeToBytesAsync<T>()` - Async encoding to UTF-8 bytes
- `EncodeToStreamAsync<T>()` - Async encoding directly to stream

### ToonDecoder
- `DecodeAsync()` / `DecodeAsync<T>()` - Async decoding from string
- `DecodeAsync(stream)` / `DecodeAsync<T>(stream)` - Async decoding from stream

All methods support `CancellationToken` for cancellation.

## Why?

- Modern .NET applications rely heavily on async/await patterns
- Stream-based operations benefit from true async I/O
- Follows .NET library design guidelines

## Testing

Added 15 new tests in `ToonAsyncTests.cs` covering:
- Basic encode/decode operations
- Stream operations  
- Cancellation token support
- Round-trip verification
- Error handling

## Checklist

- [x] Code follows project conventions
- [x] XML documentation added
- [x] Unit tests added and passing
- [x] No breaking changes