### PR TITLE
Netstandard20

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,8 @@ dotnet test --collect:"XPlat Code Coverage"
 
 ### .NET Version Support
 
-We target .NET 8.0 and .NET 9.0 for broad compatibility.
+We target .NET Standard 2.0 for maximum compatibility across .NET Framework, .NET Core, and .NET 5+.  On Windows machines, the `net481` development
+framework will need to be installed to validate .NET Standard
 
 ### Type Safety
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    </PropertyGroup>
+
+    <!-- 
+        1. CI Builds only run tests on modern supported frameworks 
+        2. Local builds run tests on .NET Framework 4.8.1 (Windows only) and modern supported frameworks
+    -->
+    <Choose>
+        <When Condition=" '$(CI)' == 'true'">
+            <PropertyGroup>
+                <TestTargetFrameworks>net8.0;net9.0;net10.0</TestTargetFrameworks>
+            </PropertyGroup>
+        </When>
+
+        <Otherwise>
+
+            <Choose>
+                <When Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">
+                    <PropertyGroup>
+                        <TestTargetFrameworks>net481;net8.0;net9.0;net10.0</TestTargetFrameworks>
+                    </PropertyGroup>
+                </When>
+
+                <Otherwise>
+                    <PropertyGroup>
+                        <TestTargetFrameworks>net8.0;net9.0;net10.0</TestTargetFrameworks>
+                    </PropertyGroup>
+                </Otherwise>
+            </Choose>
+
+        </Otherwise>
+    </Choose>
+</Project>

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # TOON Format for .NET
 
 [![NuGet version](https://img.shields.io/nuget/v/Toon.Format.svg)](https://www.nuget.org/packages/Toon.Format/)
-[![.NET version](https://img.shields.io/badge/.NET-8.0%20%7C%209.0-512BD4)](https://dotnet.microsoft.com/)
+[![.NET version](https://img.shields.io/badge/.NET-Standard%202.0-512BD4)](https://dotnet.microsoft.com/)
+[![.NET version](https://img.shields.io/badge/.NET-8.0%20%7C%209.0%20%7C10.0-512BD4)](https://dotnet.microsoft.com/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 **Token-Oriented Object Notation** is a compact, human-readable encoding of the JSON data model that minimizes tokens and makes structure easy for models to follow. Combines YAML-like indentation with CSV-like tabular arrays. Fully compatible with the [official TOON specification v3.0](https://github.com/toon-format/spec).
 
-**Key Features:** Minimal syntax • TOON Encoding and Decoding • Tabular arrays for uniform data • Path expansion • Strict mode validation • .NET 8.0, 9.0 and 10.0 • 520+ tests with 99.7% spec coverage.
+**Key Features:** Minimal syntax • TOON Encoding and Decoding • Tabular arrays for uniform data • Path expansion • Strict mode validation • .NET Standard, .NET 8.0, 9.0 and 10.0 • 520+ tests with 99.7% spec coverage.
 
 ## Quick Start
 
@@ -253,7 +254,7 @@ This implementation:
 - Supports all TOON v3.0 features
 - Handles all edge cases and strict mode validations
 - Fully documented with XML comments
-- Production-ready for .NET 8.0, .NET 9.0 and .NET 10.0
+- Production-ready for .NET Standard 2.0, .NET 8.0, .NET 9.0 and .NET 10.0
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
 

--- a/src/ToonFormat/Internal/Decode/Parser.cs
+++ b/src/ToonFormat/Internal/Decode/Parser.cs
@@ -47,7 +47,11 @@ namespace Toon.Format.Internal.Decode
             int bracketStart = -1;
 
             // For quoted keys, find bracket after closing quote (not inside the quoted string)
+#if NETSTANDARD2_0
+            if (trimmed.StartsWith(Constants.DOUBLE_QUOTE.ToString()))
+#else
             if (trimmed.StartsWith(Constants.DOUBLE_QUOTE))
+#endif
             {
                 var closingQuoteIndex = StringUtils.FindClosingQuote(trimmed, 0);
                 if (closingQuoteIndex == -1)

--- a/src/ToonFormat/Internal/Decode/Scanner.cs
+++ b/src/ToonFormat/Internal/Decode/Scanner.cs
@@ -188,9 +188,9 @@ namespace Toon.Format.Internal.Decode
                 }
                 parsed.Add(new ParsedLine
                 {
-                    Raw = new string(lineSpan),
+                    Raw = lineSpan.ToString(),
+                    Content = contentSpan.ToString(),
                     Indent = indent,
-                    Content = new string(contentSpan),
                     Depth = lineDepth,
                     LineNumber = lineNumber
                 });

--- a/src/ToonFormat/Internal/Decode/Scanner.cs
+++ b/src/ToonFormat/Internal/Decode/Scanner.cs
@@ -189,8 +189,8 @@ namespace Toon.Format.Internal.Decode
                 parsed.Add(new ParsedLine
                 {
                     Raw = lineSpan.ToString(),
-                    Content = contentSpan.ToString(),
                     Indent = indent,
+                    Content = contentSpan.ToString(),
                     Depth = lineDepth,
                     LineNumber = lineNumber
                 });

--- a/src/ToonFormat/Internal/Encode/Encoders.cs
+++ b/src/ToonFormat/Internal/Encode/Encoders.cs
@@ -57,7 +57,7 @@ namespace Toon.Format.Internal.Encode
         /// <summary>
         /// Encodes a JsonObject as key-value pairs.
         /// </summary>
-        public static void EncodeObject(JsonObject value, LineWriter writer, int depth, ResolvedEncodeOptions options, IReadOnlySet<string>? rootLiteralKeys = null,
+        public static void EncodeObject(JsonObject value, LineWriter writer, int depth, ResolvedEncodeOptions options, IReadOnlyCollection<string>? rootLiteralKeys = null,
             string? pathPrefix = null, int? remainingDepth = null)
         {
             var keys = (value as IDictionary<string, JsonNode>).Keys!;
@@ -96,7 +96,7 @@ namespace Toon.Format.Internal.Encode
             int depth,
             ResolvedEncodeOptions options,
             IReadOnlyCollection<string>? siblings = null,
-            IReadOnlySet<string>? rootLiteralKeys = null,
+            IReadOnlyCollection<string>? rootLiteralKeys = null,
             string? pathPrefix = null,
             int? flattenDepth = null)
         {

--- a/src/ToonFormat/Internal/Encode/Folding.cs
+++ b/src/ToonFormat/Internal/Encode/Folding.cs
@@ -46,7 +46,7 @@ namespace Toon.Format.Internal.Encode
 
     internal static class Folding
     {
-        public static FoldResult? TryFoldKeyChain(string key, JsonNode? value, IReadOnlyCollection<string> siblings, ResolvedEncodeOptions options, IReadOnlySet<string>? rootLiteralKeys = null,
+        public static FoldResult? TryFoldKeyChain(string key, JsonNode? value, IReadOnlyCollection<string> siblings, ResolvedEncodeOptions options, IReadOnlyCollection<string>? rootLiteralKeys = null,
             string? pathPrefix = null, int? flattenDepth = null)
         {
             // Only fold when safe mode is enabled
@@ -149,7 +149,11 @@ namespace Toon.Format.Internal.Encode
 
         private static string BuildFoldedKey(IReadOnlyCollection<string> segments)
         {
+#if NETSTANDARD2_0
+            return string.Join(Constants.DOT.ToString(), segments);
+#else
             return string.Join(Constants.DOT, segments);
+#endif
         }
     }
 }

--- a/src/ToonFormat/Internal/Encode/Normalize.cs
+++ b/src/ToonFormat/Internal/Encode/Normalize.cs
@@ -22,6 +22,7 @@ namespace Toon.Format.Internal.Encode
         /// Normalizes an arbitrary .NET value to a JsonNode representation.
         /// Handles primitives, collections, dates, and custom objects.
         /// </summary>
+        /// <param name="value">The value to be normalized.</param>
         public static JsonNode? NormalizeValue(object? value)
         {
             // null
@@ -40,7 +41,7 @@ namespace Toon.Format.Internal.Encode
             {
                 // Canonicalize signed zero via FloatUtils
                 var dn = FloatUtils.NormalizeSignedZero(d);
-                if (!double.IsFinite(dn))
+                if (!NumericUtils.IsFinite(dn))
                     return null;
                 return JsonValue.Create(dn);
             }
@@ -49,7 +50,7 @@ namespace Toon.Format.Internal.Encode
             {
                 // Canonicalize signed zero via FloatUtils
                 var fn = FloatUtils.NormalizeSignedZero(f);
-                if (!float.IsFinite(fn))
+                if (!NumericUtils.IsFinite(fn))
                     return null;
                 return JsonValue.Create(fn);
             }
@@ -138,11 +139,16 @@ namespace Toon.Format.Internal.Encode
                     return JsonValue.Create(l);
                 case double d:
                     if (BitConverter.DoubleToInt64Bits(d) == BitConverter.DoubleToInt64Bits(-0.0)) return JsonValue.Create(0.0);
-                    if (!double.IsFinite(d)) return null;
+                    if (!NumericUtils.IsFinite(d)) return null;
                     return JsonValue.Create(d);
                 case float f:
+#if NETSTANDARD2_0
+                    // netstandard does not have BitConverter.SingleToInt32Bits
+                    if (FloatUtils.NormalizeSignedZero(f).Equals(0.0f)) return JsonValue.Create(0.0f);
+#else
                     if (BitConverter.SingleToInt32Bits(f) == BitConverter.SingleToInt32Bits(-0.0f)) return JsonValue.Create(0.0f);
-                    if (!float.IsFinite(f)) return null;
+#endif
+                    if (!NumericUtils.IsFinite(f)) return null;
                     return JsonValue.Create(f);
                 case decimal dec:
                     return JsonValue.Create(dec);

--- a/src/ToonFormat/Internal/Encode/Primitives.cs
+++ b/src/ToonFormat/Internal/Encode/Primitives.cs
@@ -52,7 +52,11 @@ namespace Toon.Format.Internal.Encode
                 if (result.Contains('.'))
                 {
                     result = result.TrimEnd('0');
-                    if (result.EndsWith('.'))
+#if NETSTANDARD2_0
+                    if (result.EndsWith(Constants.DOT.ToString()))
+#else
+                    if (result.EndsWith(Constants.DOT))
+#endif
                         result = result.TrimEnd('.');
                 }
 

--- a/src/ToonFormat/Internal/Shared/FloatUtils.cs
+++ b/src/ToonFormat/Internal/Shared/FloatUtils.cs
@@ -14,13 +14,13 @@ namespace Toon.Format.Internal.Shared
         /// <returns></returns>
         public static bool NearlyEqual(double a, double b, double absEps = 1e-12, double relEps = 1e-9)
         {
-            if (double.IsNaN(a) && double.IsNaN(b)) return true;     // ҵ���ϳ���Ҫ�� NaN == NaN
+            if (double.IsNaN(a) && double.IsNaN(b)) return true;
             if (double.IsInfinity(a) || double.IsInfinity(b)) return a.Equals(b);
-            if (a == b) return true;                                  // ���� 0.0 == -0.0����ȫ���
+            if (a == b) return true;
 
             var diff = Math.Abs(a - b);
             var scale = Math.Max(Math.Abs(a), Math.Abs(b));
-            if (scale == 0) return diff <= absEps;                    // ���߶��ӽ� 0
+            if (scale == 0) return diff <= absEps;
             return diff <= Math.Max(absEps, relEps * scale);
         }
 
@@ -35,7 +35,19 @@ namespace Toon.Format.Internal.Shared
         /// <summary>
         /// Explicitly change -0.0f to +0.0f for float values.
         /// </summary>
-        public static float NormalizeSignedZero(float v) =>
-            BitConverter.SingleToInt32Bits(v) == BitConverter.SingleToInt32Bits(-0.0f) ? 0.0f : v;
+        public static float NormalizeSignedZero(float v)
+        {
+#if NETSTANDARD2_0
+            unsafe
+            {
+                int* vBits = (int*)&v;
+                float negZero = -0.0f;
+                int* zeroBits = (int*)&negZero;
+                return *vBits == *zeroBits ? 0.0f : v;
+            }
+#else
+            return BitConverter.SingleToInt32Bits(v) == BitConverter.SingleToInt32Bits(-0.0f) ? 0.0f : v;
+#endif
+        }
     }
 }

--- a/src/ToonFormat/Internal/Shared/NumericUtils.cs
+++ b/src/ToonFormat/Internal/Shared/NumericUtils.cs
@@ -1,9 +1,12 @@
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
 namespace Toon.Format.Internal.Shared
 {
     internal static class NumericUtils
     {
+        internal const ulong PositiveInfinityBits = 0x7FF0_0000_0000_0000;
+
         /// <summary>
         /// Converts a double to a decimal in canonical form for accurate representation.
         /// </summary>
@@ -43,6 +46,24 @@ namespace Toon.Format.Internal.Shared
             decimalValue *= (decimal)Math.Pow(10, exponent);
 
             return decimalValue;
+        }
+
+        public static bool IsFinite(double value)
+        {
+#if NETSTANDARD2_0
+            return !(double.IsNaN(value) || double.IsInfinity(value));
+#else
+            return double.IsFinite(value);
+#endif
+        }
+
+        public static bool IsFinite(float value)
+        {
+#if NETSTANDARD2_0
+            return !(float.IsNaN(value) || float.IsInfinity(value));
+#else
+            return float.IsFinite(value);
+#endif
         }
     }
 }

--- a/src/ToonFormat/Internal/Shared/NumericUtils.cs
+++ b/src/ToonFormat/Internal/Shared/NumericUtils.cs
@@ -5,8 +5,6 @@ namespace Toon.Format.Internal.Shared
 {
     internal static class NumericUtils
     {
-        internal const ulong PositiveInfinityBits = 0x7FF0_0000_0000_0000;
-
         /// <summary>
         /// Converts a double to a decimal in canonical form for accurate representation.
         /// </summary>

--- a/src/ToonFormat/System.Diagnostics.CodeAnalysis/SetsRequiredMembersAttribute.cs
+++ b/src/ToonFormat/System.Diagnostics.CodeAnalysis/SetsRequiredMembersAttribute.cs
@@ -1,0 +1,12 @@
+﻿#if NETSTANDARD2_0
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Compiler attribute for setting required members
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = true)]
+    public sealed class SetsRequiredMembersAttribute : Attribute { }
+}
+
+#endif

--- a/src/ToonFormat/System.Runtime.CompilerServices/CompilerFeatureRequiredAttribute.cs
+++ b/src/ToonFormat/System.Runtime.CompilerServices/CompilerFeatureRequiredAttribute.cs
@@ -12,6 +12,7 @@ namespace System.Runtime.CompilerServices
     {
         public CompilerFeatureRequiredAttribute(string featureName)
         {
+            FeatureName = featureName;
         }
 
         public string FeatureName { get; }

--- a/src/ToonFormat/System.Runtime.CompilerServices/CompilerFeatureRequiredAttribute.cs
+++ b/src/ToonFormat/System.Runtime.CompilerServices/CompilerFeatureRequiredAttribute.cs
@@ -12,8 +12,8 @@ namespace System.Runtime.CompilerServices
     /// Indicates that a compiler feature is required.
     /// </summary>
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
-    public sealed class CompilerFeatureRequiredAttribute : Attribute 
-    { 
+    public sealed class CompilerFeatureRequiredAttribute : Attribute
+    {
         public CompilerFeatureRequiredAttribute(string featureName)
         {
         }

--- a/src/ToonFormat/System.Runtime.CompilerServices/CompilerFeatureRequiredAttribute.cs
+++ b/src/ToonFormat/System.Runtime.CompilerServices/CompilerFeatureRequiredAttribute.cs
@@ -1,5 +1,4 @@
 ﻿#if NETSTANDARD2_0
-
 using System;
 
 namespace System.Runtime.CompilerServices
@@ -10,11 +9,18 @@ namespace System.Runtime.CompilerServices
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
     public sealed class CompilerFeatureRequiredAttribute : Attribute
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompilerFeatureRequiredAttribute"/> class.
+        /// </summary>
+        /// <param name="featureName">The name of the feature.</param>
         public CompilerFeatureRequiredAttribute(string featureName)
         {
             FeatureName = featureName;
         }
 
+        /// <summary>
+        /// Gets the name of the feature.
+        /// </summary>
         public string FeatureName { get; }
     }
 }

--- a/src/ToonFormat/System.Runtime.CompilerServices/CompilerFeatureRequiredAttribute.cs
+++ b/src/ToonFormat/System.Runtime.CompilerServices/CompilerFeatureRequiredAttribute.cs
@@ -1,0 +1,25 @@
+﻿#if NETSTANDARD2_0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Indicates that a compiler feature is required.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+    public sealed class CompilerFeatureRequiredAttribute : Attribute 
+    { 
+        public CompilerFeatureRequiredAttribute(string featureName)
+        {
+        }
+
+        public string FeatureName { get; }
+    }
+}
+
+#endif

--- a/src/ToonFormat/System.Runtime.CompilerServices/CompilerFeatureRequiredAttribute.cs
+++ b/src/ToonFormat/System.Runtime.CompilerServices/CompilerFeatureRequiredAttribute.cs
@@ -1,10 +1,6 @@
 ﻿#if NETSTANDARD2_0
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace System.Runtime.CompilerServices
 {

--- a/src/ToonFormat/System.Runtime.CompilerServices/RequiredMemberAttribute.cs
+++ b/src/ToonFormat/System.Runtime.CompilerServices/RequiredMemberAttribute.cs
@@ -1,0 +1,18 @@
+﻿#if NETSTANDARD2_0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Attribute for decorating members as required.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+    public sealed class RequiredMemberAttribute : Attribute { }
+}
+
+#endif

--- a/src/ToonFormat/System.Runtime.CompilerServices/RequiredMemberAttribute.cs
+++ b/src/ToonFormat/System.Runtime.CompilerServices/RequiredMemberAttribute.cs
@@ -1,10 +1,6 @@
 ﻿#if NETSTANDARD2_0
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace System.Runtime.CompilerServices
 {

--- a/src/ToonFormat/ToonDecoder.cs
+++ b/src/ToonFormat/ToonDecoder.cs
@@ -184,8 +184,14 @@ public static class ToonDecoder
     {
         if (stream == null)
             throw new ArgumentNullException(nameof(stream));
+
+#if NETSTANDARD2_0
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
+#else
         using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: true);
+#endif
         var text = reader.ReadToEnd();
+
         return Decode(text, options ?? new ToonDecodeOptions());
     }
 
@@ -209,8 +215,15 @@ public static class ToonDecoder
     {
         if (stream == null)
             throw new ArgumentNullException(nameof(stream));
+
+#if NETSTANDARD2_0
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
+#else
         using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: true);
+#endif
+
         var text = reader.ReadToEnd();
+
         return Decode<T>(text, options ?? new ToonDecodeOptions());
     }
 
@@ -296,9 +309,14 @@ public static class ToonDecoder
         if (stream == null)
             throw new ArgumentNullException(nameof(stream));
 
+#if NETSTANDARD2_0
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
+        var text = await reader.ReadToEndAsync().ConfigureAwait(false);
+#else
         using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: true);
         var text = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
-        return Decode(text, options ?? new ToonDecodeOptions());
+#endif
+        return await DecodeAsync(text, options ?? new ToonDecodeOptions(), cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -327,9 +345,14 @@ public static class ToonDecoder
         if (stream == null)
             throw new ArgumentNullException(nameof(stream));
 
+#if NETSTANDARD2_0
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
+        var text = await reader.ReadToEndAsync().ConfigureAwait(false);
+#else
         using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: true);
         var text = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
-        return Decode<T>(text, options ?? new ToonDecodeOptions());
+#endif
+        return await DecodeAsync<T>(text, options ?? new ToonDecodeOptions(), cancellationToken: cancellationToken);
     }
 
     #endregion

--- a/src/ToonFormat/ToonFormat.csproj
+++ b/src/ToonFormat/ToonFormat.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFrameworks>$(TargetFrameworks)</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>

--- a/src/ToonFormat/ToonFormat.csproj
+++ b/src/ToonFormat/ToonFormat.csproj
@@ -1,30 +1,39 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <LangVersion>latest</LangVersion>
-    <RootNamespace>Toon.Format</RootNamespace>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<LangVersion>latest</LangVersion>
+		<RootNamespace>Toon.Format</RootNamespace>
 
-    <!-- Package Information -->
-    <PackageId>Toon.Format</PackageId>
-    <Version>0.1.0</Version>
-    <Authors>Johann Schopplich</Authors>
-    <Company>Johann Schopplich</Company>
-    <Description>Token-Oriented Object Notation (TOON) - a token-efficient JSON alternative for LLM prompts</Description>
-    <PackageTags>toon;format;llm;token;serialization;json</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://toonformat.dev</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/toon-format/toon-dotnet</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+		<!-- Package Information -->
+		<PackageId>Toon.Format</PackageId>
+		<Version>0.1.0</Version>
+		<Authors>Johann Schopplich</Authors>
+		<Company>Johann Schopplich</Company>
+		<Description>Token-Oriented Object Notation (TOON) - a token-efficient JSON alternative for LLM prompts</Description>
+		<PackageTags>toon;format;llm;token;serialization;json</PackageTags>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://toonformat.dev</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/toon-format/toon-dotnet</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+		<PackageReference Include="System.Collections.Immutable" Version="10.0.2" />
+		<PackageReference Include="System.Text.Json" Version="10.0.2" />
+	</ItemGroup>
+
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+	</PropertyGroup>
 
 
 </Project>

--- a/tests/ToonFormat.SpecGenerator/ToonFormat.SpecGenerator.csproj
+++ b/tests/ToonFormat.SpecGenerator/ToonFormat.SpecGenerator.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ToonFormat.SpecGenerator/ToonFormat.SpecGenerator.csproj
+++ b/tests/ToonFormat.SpecGenerator/ToonFormat.SpecGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>

--- a/tests/ToonFormat.Tests/ManualTests/PerformanceBenchmark.cs
+++ b/tests/ToonFormat.Tests/ManualTests/PerformanceBenchmark.cs
@@ -37,7 +37,7 @@ public class PerformanceBenchmark
         sw.Stop();
 
         _output.WriteLine($"Simple encoding: {sw.ElapsedMilliseconds}ms for 10,000 iterations");
-        _output.WriteLine($"Average: {sw.Elapsed.TotalMicroseconds / 10000:F2}μs per encode");
+        _output.WriteLine($"Average: {sw.Elapsed.Ticks / 100000:F2}μs per encode");
 
         // Baseline: should complete in reasonable time (< 5 seconds for 10k iterations)
         Assert.True(sw.ElapsedMilliseconds < 5000, $"Encoding took {sw.ElapsedMilliseconds}ms, expected < 5000ms");
@@ -61,7 +61,7 @@ users[3]{id,name,role}:
         sw.Stop();
 
         _output.WriteLine($"Simple decoding: {sw.ElapsedMilliseconds}ms for 10,000 iterations");
-        _output.WriteLine($"Average: {sw.Elapsed.TotalMicroseconds / 10000:F2}μs per decode");
+        _output.WriteLine($"Average: {sw.Elapsed.Ticks / 100000:F2}μs per decode");
 
         // Baseline: should complete in reasonable time (< 5 seconds for 10k iterations)
         Assert.True(sw.ElapsedMilliseconds < 5000, $"Decoding took {sw.ElapsedMilliseconds}ms, expected < 5000ms");
@@ -95,7 +95,7 @@ users[3]{id,name,role}:
         sw.Stop();
 
         _output.WriteLine($"Section 10 encoding: {sw.ElapsedMilliseconds}ms for 10,000 iterations");
-        _output.WriteLine($"Average: {sw.Elapsed.TotalMicroseconds / 10000:F2}μs per encode");
+        _output.WriteLine($"Average: {sw.Elapsed.Ticks / 100000:F2}μs per encode");
 
         // Baseline: should complete in reasonable time
         Assert.True(sw.ElapsedMilliseconds < 5000, $"Section 10 encoding took {sw.ElapsedMilliseconds}ms, expected < 5000ms");
@@ -123,7 +123,7 @@ users[3]{id,name,role}:
         sw.Stop();
 
         _output.WriteLine($"Round-trip: {sw.ElapsedMilliseconds}ms for 5,000 iterations");
-        _output.WriteLine($"Average: {sw.Elapsed.TotalMicroseconds / 5000:F2}μs per round-trip");
+        _output.WriteLine($"Average: {sw.Elapsed.Ticks / 50000:F2}μs per round-trip");
 
         // Baseline: should complete in reasonable time
         Assert.True(sw.ElapsedMilliseconds < 5000, $"Round-trip took {sw.ElapsedMilliseconds}ms, expected < 5000ms");

--- a/tests/ToonFormat.Tests/ToonFormat.Tests.csproj
+++ b/tests/ToonFormat.Tests/ToonFormat.Tests.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <RootNamespace>Toon.Format.Tests</RootNamespace>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ToonFormat.Tests/ToonFormat.Tests.csproj
+++ b/tests/ToonFormat.Tests/ToonFormat.Tests.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <RootNamespace>Toon.Format.Tests</RootNamespace>
+	<LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Linked Issue

<!-- Reference the related issue. Example: Closes #123 -->

Closes #25 and #20

## Description

<!-- Provide a clear and concise description of your changes -->
This minimizes the surface area of impact by making this library netstandard2.0 compliant and using specific attributes for compatibility.

## Type of Change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

<!-- List the main changes in this PR -->

- Adds .netstandard2.0 support
    - References `System.Text.Json` and `System.Collections.Immutable` for compatibility
    - Minor changes for APIs that do not exist in the `netstandard20` world
    - Adds tests for net481 on windows machines for local development only
- Updates documentation

## SPEC Compliance

<!-- If this PR relates to the TOON spec, indicate which sections are affected -->

- [ ] This PR implements/fixes spec compliance
- [ ] Spec section(s) affected:
- [ ] Spec version:

## Testing

<!-- Describe the tests you added or ran -->

- [x] All existing tests pass
- [x] Added new tests for changes
- [ ] Tests cover edge cases and spec compliance

## Pre-submission Checklist

<!-- Verify before submitting -->

- [x] My code follows the project's coding standards
- [x] I have run code formatting/linting tools
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
- [ ] I have reviewed the [TOON specification](https://github.com/toon-format/spec) for relevant sections

## Breaking Changes

<!-- If this is a breaking change, describe the migration path for users -->

- [x] No breaking changes
- [ ] Breaking changes (describe migration path below)

<!-- Migration path: -->

## Additional Context

<!-- Add any other context about the PR here (optional) -->
